### PR TITLE
Get discussions API

### DIFF
--- a/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
+++ b/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
@@ -44,3 +44,32 @@ GitlabDiscussionsTest >> testCreateThreadInMergeRequestOfProjectBodyPosition [
 	"Then"
 	self assert: (result at: #message) equals: (response at: #message).
 ]
+
+{ #category : 'tests' }
+GitlabDiscussionsTest >> testGetAllInMRInProject [
+
+	| hostUrl client gitlabApi projectId mergeRequestIID objectId object gitlabDiscussions endpoint result |
+	hostUrl := 'https://www.url.com'.
+	client := ZnClient new.
+
+	gitlabApi := GitlabApi new privateToken: 'token'; hostUrl: hostUrl; client: client.
+
+	projectId := 1.
+	mergeRequestIID := 42.
+
+	objectId := 'abc123'.
+	object := { #id -> objectId } asDictionary.
+
+	gitlabDiscussions := GitlabDiscussions new gitlabAPI: gitlabApi.
+
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions'.
+	(gitlabDiscussions stub getAllinMR: mergeRequestIID inProject: projectId) willReturn: { object }.
+
+	"When"
+	result := gitlabDiscussions getAllinMR: mergeRequestIID inProject: projectId.
+
+	"Then"
+	self assert: result size equals: 1.
+	self assert: (result first at: #id) equals: objectId.
+
+]

--- a/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
+++ b/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
@@ -48,58 +48,72 @@ GitlabDiscussionsTest >> testCreateThreadInMergeRequestOfProjectBodyPosition [
 { #category : 'tests' }
 GitlabDiscussionsTest >> testGetAllInMRInProject [
 
-	| hostUrl client gitlabApi projectId mergeRequestIID objectId object gitlabDiscussions endpoint result |
+	| hostUrl client gitlabApi projectId mergeRequestIID discussionId objectId object gitlabDiscussions endpoint result objectId2 object2 object3|
 	hostUrl := 'https://www.url.com'.
 	client := ZnClient new.
 
-	gitlabApi := GitlabApi new privateToken: 'token'; hostUrl: hostUrl; client: client.
-
+	gitlabApi := GitlabApi new
+		             privateToken: 'token';
+		             hostUrl: hostUrl;
+		             client: client.
 	projectId := 1.
 	mergeRequestIID := 42.
+	discussionId := 'abc123'.
 
-	objectId := 'abc123'.
-	object := { #id -> objectId } asDictionary.
+	objectId := 'def456'.
+	object := { (#id -> objectId) } asDictionary.
+
+	objectId2 := 'abc123'.
+	object2 := { (#id -> objectId2) } asDictionary.
+
+	object3 := { object. object2 }.
 
 	gitlabDiscussions := GitlabDiscussions new gitlabAPI: gitlabApi.
+	endpoint := '/projects/' , projectId asString , '/merge_requests/' , mergeRequestIID asString , '/discussions'.
 
-	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions'.
-	(gitlabDiscussions stub getAllinMR: mergeRequestIID inProject: projectId) willReturn: { object }.
+	(gitlabDiscussions stub get: endpoint withParams: Dictionary new) willReturn: object3.
 
-	"When"
-	result := gitlabDiscussions getAllinMR: mergeRequestIID inProject: projectId.
+	result := gitlabDiscussions getAllInMR: mergeRequestIID inProject: projectId.
 
-	"Then"
-	self assert: result size equals: 1.
 	self assert: (result first at: #id) equals: objectId.
+	self assert: result size equals: 2.
 
 ]
 
 { #category : 'tests' }
-GitlabDiscussionsTest >> testGetInMRInProjectADiscussion [
-
+GitlabDiscussionsTest >> testGetInMergeRequestOfProject [
 	"Given"
+
 	| hostUrl client gitlabApi projectId mergeRequestIID discussionId objectId object gitlabDiscussions endpoint result |
 	hostUrl := 'https://www.url.com'.
 	client := ZnClient new.
 
-	gitlabApi := GitlabApi new privateToken: 'token'; hostUrl: hostUrl; client: client.
+	gitlabApi := GitlabApi new
+		             privateToken: 'token';
+		             hostUrl: hostUrl;
+		             client: client.
 
 	projectId := 1.
 	mergeRequestIID := 42.
 	discussionId := 'abc123'.
 
 	objectId := 'def456'.
-	object := { #id -> objectId } asDictionary.
+	object := { (#id -> objectId) } asDictionary.
 
 	gitlabDiscussions := GitlabDiscussions new gitlabAPI: gitlabApi.
 
-	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions/', discussionId.
-	(gitlabDiscussions stub getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId) willReturn: object.
+	endpoint := '/projects/' , projectId asString , '/merge_requests/'
+	            , mergeRequestIID asString , '/discussions/'
+	            , discussionId.
+	
+	(gitlabDiscussions stub get: endpoint withParams: Dictionary new)
+		willReturn: object.
 
-	"When"
-	result := gitlabDiscussions getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId.
+	result := gitlabDiscussions
+		          get: discussionId
+		          inMergeRequest: mergeRequestIID
+		          ofProject: projectId.
 
-	"Then"
-	self assert: (result at: #id) equals: objectId.
+	self assert: (result at: #id) equals: objectId
 
 ]

--- a/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
+++ b/src/GitlabAPI-Discussions-Tests/GitlabDiscussionsTest.class.st
@@ -73,3 +73,33 @@ GitlabDiscussionsTest >> testGetAllInMRInProject [
 	self assert: (result first at: #id) equals: objectId.
 
 ]
+
+{ #category : 'tests' }
+GitlabDiscussionsTest >> testGetInMRInProjectADiscussion [
+
+	"Given"
+	| hostUrl client gitlabApi projectId mergeRequestIID discussionId objectId object gitlabDiscussions endpoint result |
+	hostUrl := 'https://www.url.com'.
+	client := ZnClient new.
+
+	gitlabApi := GitlabApi new privateToken: 'token'; hostUrl: hostUrl; client: client.
+
+	projectId := 1.
+	mergeRequestIID := 42.
+	discussionId := 'abc123'.
+
+	objectId := 'def456'.
+	object := { #id -> objectId } asDictionary.
+
+	gitlabDiscussions := GitlabDiscussions new gitlabAPI: gitlabApi.
+
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions/', discussionId.
+	(gitlabDiscussions stub getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId) willReturn: object.
+
+	"When"
+	result := gitlabDiscussions getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId.
+
+	"Then"
+	self assert: (result at: #id) equals: objectId.
+
+]

--- a/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
+++ b/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
@@ -30,3 +30,13 @@ GitlabDiscussions >> getAllinMR: mergeRequestIID inProject: projectId [
 	
 	^self get: endpoint withParams: Dictionary new.
 ]
+
+{ #category : 'api' }
+GitlabDiscussions >> getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId [
+	"https://docs.gitlab.com/api/discussions/#get-single-merge-request-discussion-item"
+	
+	| endpoint |
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions/', discussionId.
+	
+	^self get: endpoint withParams: Dictionary new.
+]

--- a/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
+++ b/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
@@ -22,21 +22,21 @@ GitlabDiscussions >> createThreadInMergeRequest: mergeRequestIID ofProject: proj
 ]
 
 { #category : 'api' }
-GitlabDiscussions >> getAllinMR: mergeRequestIID inProject: projectId [
-	"https://docs.gitlab.com/api/discussions/#list-project-merge-request-discussion-items"
+GitlabDiscussions >> get: discussionId inMergeRequest: mergeRequestIID ofProject: projectId [
+	"https://docs.gitlab.com/api/discussions/#get-single-merge-request-discussion-item"
 	
 	| endpoint |
-	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions'.
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions/', discussionId.
 	
 	^self get: endpoint withParams: Dictionary new.
 ]
 
 { #category : 'api' }
-GitlabDiscussions >> getinMR: mergeRequestIID inProject: projectId aDiscussion: discussionId [
-	"https://docs.gitlab.com/api/discussions/#get-single-merge-request-discussion-item"
+GitlabDiscussions >> getAllInMR: mergeRequestIID inProject: projectId [
+	"https://docs.gitlab.com/api/discussions/#list-project-merge-request-discussion-items"
 	
 	| endpoint |
-	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions/', discussionId.
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions'.
 	
 	^self get: endpoint withParams: Dictionary new.
 ]

--- a/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
+++ b/src/GitlabAPI-Discussions/GitlabDiscussions.class.st
@@ -20,3 +20,13 @@ GitlabDiscussions >> createThreadInMergeRequest: mergeRequestIID ofProject: proj
 	
 	^self post: endpoint withData: data.
 ]
+
+{ #category : 'api' }
+GitlabDiscussions >> getAllinMR: mergeRequestIID inProject: projectId [
+	"https://docs.gitlab.com/api/discussions/#list-project-merge-request-discussion-items"
+	
+	| endpoint |
+	endpoint := '/projects/', projectId asString, '/merge_requests/', mergeRequestIID asString, '/discussions'.
+	
+	^self get: endpoint withParams: Dictionary new.
+]


### PR DESCRIPTION
Hi,

This PR adds support for retrieving discussions from the GitLab API.

Specifically, it implements:

[Get a single merge request discussion item](https://docs.gitlab.com/api/discussions/#get-single-merge-request-discussion-item)

[List all discussions of a merge request](https://docs.gitlab.com/api/discussions/#list-project-merge-request-discussion-items)

Let me know if anything needs to be adjusted.

Thanks,
Marpioux