### PR TITLE
Default client throws on HTTP errors

### DIFF
--- a/src/GitlabAPI-Core/GitlabApi.class.st
+++ b/src/GitlabAPI-Core/GitlabApi.class.st
@@ -24,9 +24,9 @@ GitlabApi >> client [
 ]
 
 { #category : 'accessing' }
-GitlabApi >> client: anObject [
+GitlabApi >> client: aZnClient [
 
-	client := anObject
+	client := aZnClient
 ]
 
 { #category : 'ressources' }
@@ -62,9 +62,9 @@ GitlabApi >> hostUrl: anObject [
 { #category : 'initialization' }
 GitlabApi >> initialize [
 
-	client := ZnClient new
-		          accept: ZnMimeType applicationJson;
-		          yourself
+	(client := ZnClient new)
+		systemPolicy;
+		accept: ZnMimeType applicationJson
 ]
 
 { #category : 'ressources' }


### PR DESCRIPTION
Use `ZnClient >> systemPolicy` on the default client instantiated by `GitlabApi` to enforce HTTP success.
The goal is to get clear errors when HTTP requests fail, rather than getting errors when parsing error messages as if it were the entities the API asked for.
This also adds two retry attempts and enforces setting the accepted content type, which should not hurt.