### PR TITLE
Put private token instead of adding

### DIFF
--- a/src/GitlabAPI-Core/GitlabApi.class.st
+++ b/src/GitlabAPI-Core/GitlabApi.class.st
@@ -104,10 +104,10 @@ GitlabApi >> pipelines [
 ]
 
 { #category : 'accessing' }
-GitlabApi >> privateToken: anObject [
+GitlabApi >> privateToken: aString [
 
-	client headerAt: #'PRIVATE-TOKEN' add: anObject.
-	privateToken := anObject
+	client headerAt: #'PRIVATE-TOKEN' put: aString.
+	privateToken := aString
 ]
 
 { #category : 'ressources' }


### PR DESCRIPTION
Currently, headers accumulate tokens rather than overwriting.