### PR TITLE
Revert "Default client throws on HTTP errors"

### DIFF
--- a/src/GitlabAPI-Core/GitlabApi.class.st
+++ b/src/GitlabAPI-Core/GitlabApi.class.st
@@ -24,9 +24,9 @@ GitlabApi >> client [
 ]
 
 { #category : 'accessing' }
-GitlabApi >> client: aZnClient [
+GitlabApi >> client: anObject [
 
-	client := aZnClient
+	client := anObject
 ]
 
 { #category : 'ressources' }
@@ -62,9 +62,9 @@ GitlabApi >> hostUrl: anObject [
 { #category : 'initialization' }
 GitlabApi >> initialize [
 
-	(client := ZnClient new)
-		systemPolicy;
-		accept: ZnMimeType applicationJson
+	client := ZnClient new
+		          accept: ZnMimeType applicationJson;
+		          yourself
 ]
 
 { #category : 'ressources' }


### PR DESCRIPTION
Now I believe we should not let errors happen, instead we should always check if client is successful. This may be the responsibility of dependants rather than this project's.